### PR TITLE
Remove unnecessary import of get_oldest_mcp_parent

### DIFF
--- a/analysis/pylcio/drivers/cal_hits_mcp.py
+++ b/analysis/pylcio/drivers/cal_hits_mcp.py
@@ -5,7 +5,6 @@ from pyLCIO.drivers.Driver import Driver
 from pyLCIO import EVENT, UTIL
 
 from pdb import set_trace
-from utils import get_oldest_mcp_parent
 
 CONST_C = R.TMath.C()
 T_MAX = 0.3 # ns


### PR DESCRIPTION
Hi @bartosik-hep . Thanks for adding this example python analysis code.

I think this line can be removed, since `get_oldest_mcp_parent` is defined within the driver file.

cc @trholmes @lawrenceleejr

